### PR TITLE
fix: changed from token to cookies on admin actors tests

### DIFF
--- a/__tests__/admin-actors.test.tsx
+++ b/__tests__/admin-actors.test.tsx
@@ -21,13 +21,19 @@ jest.mock("next/navigation", () => ({
 describe("ActoresPage", () => {
   beforeEach(() => {
     global.fetch = jest.fn();
-    Storage.prototype.getItem = jest.fn(() => "fake-token");
+    Object.defineProperty(document, "cookie", {
+      writable: true,
+      value: "token=fake-token",
+    });
     window.confirm = jest.fn(() => true);
   });
 
   afterEach(() => {
+    Object.defineProperty(document, "cookie", {
+      writable: true,
+      value: "",
+    });
     jest.clearAllMocks();
-    Storage.prototype.getItem = jest.fn();
   });
 
   afterAll(() => {
@@ -125,7 +131,6 @@ describe("ActoresPage", () => {
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith("/api/actors/1", {
         method: "DELETE",
-        headers: { Authorization: "Bearer fake-token" },
       });
       expect(mockRefresh).toHaveBeenCalled();
     });
@@ -156,13 +161,15 @@ describe("ActoresPage", () => {
 describe("EditarActorPage", () => {
   beforeEach(() => {
     global.fetch = jest.fn();
-    Storage.prototype.getItem = jest.fn(() => "fake-token");
+    Object.defineProperty(document, "cookie", {
+      writable: true,
+      value: "token=fake-token",
+    });
     window.confirm = jest.fn(() => true);
   });
 
   afterEach(() => {
     jest.clearAllMocks();
-    Storage.prototype.getItem = jest.fn();
   });
 
   afterAll(() => {
@@ -194,31 +201,7 @@ describe("EditarActorPage", () => {
     render(<EditarActorPage params={{ id: "123" }} />);
     await screen.findByText("Mock Actor Form");
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      "/api/actors/123",
-      expect.anything()
-    );
-  });
-
-  it("includes authorization token", async () => {
-    const mockToken = "fake-token";
-    Storage.prototype.getItem = jest.fn().mockReturnValue(mockToken);
-    const mockFetch = (global.fetch as jest.Mock).mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve({ id: "123", name: "Test Actor" }),
-    });
-
-    render(<EditarActorPage params={{ id: "123" }} />);
-    await screen.findByText("Mock Actor Form");
-
-    expect(mockFetch).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        headers: {
-          Authorization: `Bearer ${mockToken}`,
-        },
-      })
-    );
+    expect(mockFetch).toHaveBeenCalledWith("/api/actors/123");
   });
 
   it("handles API error responses", async () => {


### PR DESCRIPTION
## Descripción

- Se modifican tests existentes de admin actors pages para un enfoque de cookies en vez de token

- Se elimina test de _includes auth token_ por el mismo motivo

## Motivación y Contexto

Proporcionar tests básicos que supervisen el funcionamiento de  ActoresPage y EditarActorPage

## ¿Cómo ha sido probado?

 `npm test ./__tests__/admin-actors.test.tsx` 

## Capturas de pantalla:

N/A

## Tipos de cambios

- [ ] Bugfix (cambio que no interrumpe el funcionamiento y que soluciona un problema)
- [x] New feature (cambio que no interrumpe el funcionamiento y que añade funcionalidad)
- [ ] Breaking change (corrección o funcionalidad que podría causar que la funcionalidad existente cambie)

## Lista de verificación:

- [x] Mi código sigue el estilo de código de este proyecto.
- [ ] Mi cambio requiere una modificación en la documentación.
- [ ] He actualizado la documentación en consecuencia.
- [ ] Requiere nuevos tests.