### PR TITLE
feat: add forum support for events with nested replies

### DIFF
--- a/app/admin/foros/page.tsx
+++ b/app/admin/foros/page.tsx
@@ -3,7 +3,14 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Input } from "@/components/ui/input";
@@ -26,11 +33,12 @@ type ForumPost = {
 };
 
 export default function ForosPage() {
-  const [posts, setPosts] = useState<ForumPost[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
-  const [groupedPosts, setGroupedPosts] = useState<Record<string, ForumPost[]>>({});
+  const [groupedPosts, setGroupedPosts] = useState<Record<string, ForumPost[]>>(
+    {}
+  );
   const router = useRouter();
 
   useEffect(() => {
@@ -43,17 +51,20 @@ export default function ForosPage() {
         });
         if (!res.ok) throw new Error("Error al obtener los mensajes");
         const data = await res.json();
-        
+
         // Agrupar posts por evento
-        const grouped = data.reduce((acc: Record<string, ForumPost[]>, post: ForumPost) => {
-          const eventId = post.event.id;
-          if (!acc[eventId]) {
-            acc[eventId] = [];
-          }
-          acc[eventId].push(post);
-          return acc;
-        }, {});
-        
+        const grouped = data.reduce(
+          (acc: Record<string, ForumPost[]>, post: ForumPost) => {
+            const eventId = post.event.id;
+            if (!acc[eventId]) {
+              acc[eventId] = [];
+            }
+            acc[eventId].push(post);
+            return acc;
+          },
+          {}
+        );
+
         setGroupedPosts(grouped);
       } catch (err: any) {
         setError(err.message);
@@ -75,7 +86,17 @@ export default function ForosPage() {
         },
       });
       if (!res.ok) throw new Error("Error al eliminar el mensaje");
-      setPosts(posts.filter((post) => post.id !== id));
+
+      setGroupedPosts((prevGrouped) =>
+        Object.fromEntries(
+          Object.entries(prevGrouped)
+            .map(([eventId, posts]) => [
+              eventId,
+              posts.filter((post) => post.id !== id),
+            ])
+            .filter(([, posts]) => posts.length > 0)
+        )
+      );
     } catch (err: any) {
       setError(err.message);
     }
@@ -108,9 +129,7 @@ export default function ForosPage() {
         {Object.entries(groupedPosts).map(([eventId, posts]) => (
           <div key={eventId} className="mb-8 border rounded-lg p-4">
             <div className="flex justify-between items-center mb-4">
-              <h3 className="text-lg font-semibold">
-                {posts[0].event.name}
-              </h3>
+              <h3 className="text-lg font-semibold">{posts[0].event.name}</h3>
               <Button
                 variant="ghost"
                 size="sm"
@@ -119,7 +138,7 @@ export default function ForosPage() {
                 Ver Evento
               </Button>
             </div>
-            
+
             <Table>
               <TableHeader>
                 <TableRow>
@@ -164,4 +183,4 @@ export default function ForosPage() {
       </CardContent>
     </Card>
   );
-} 
+}

--- a/app/admin/foros/page.tsx
+++ b/app/admin/foros/page.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Input } from "@/components/ui/input";
+import { format } from "date-fns";
+import { es } from "date-fns/locale";
+
+type ForumPost = {
+  id: string;
+  content: string;
+  created_at: string;
+  user: {
+    id: string;
+    name: string;
+    role: string;
+  };
+  event: {
+    id: string;
+    name: string;
+  };
+};
+
+export default function ForosPage() {
+  const [posts, setPosts] = useState<ForumPost[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const router = useRouter();
+
+  useEffect(() => {
+    async function fetchPosts() {
+      try {
+        const res = await fetch("/api/admin/forum/posts", {
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem("token")}`,
+          },
+        });
+        if (!res.ok) throw new Error("Error al obtener los mensajes");
+        const data = await res.json();
+        setPosts(data);
+      } catch (err: any) {
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchPosts();
+  }, []);
+
+  const handleDelete = async (id: string) => {
+    if (!confirm("¿Estás seguro de eliminar este mensaje?")) return;
+
+    try {
+      const res = await fetch(`/api/admin/forum/posts/${id}`, {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem("token")}`,
+        },
+      });
+      if (!res.ok) throw new Error("Error al eliminar el mensaje");
+      setPosts(posts.filter((post) => post.id !== id));
+    } catch (err: any) {
+      setError(err.message);
+    }
+  };
+
+  const filteredPosts = posts.filter(
+    (post) =>
+      post.content.toLowerCase().includes(search.toLowerCase()) ||
+      post.user.name.toLowerCase().includes(search.toLowerCase()) ||
+      post.event.name.toLowerCase().includes(search.toLowerCase())
+  );
+
+  const formatDate = (dateString: string) => {
+    return format(new Date(dateString), "PPp", { locale: es });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Moderación de Foros</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {error && (
+          <Alert variant="destructive" className="mb-4">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        <div className="flex justify-between mb-4 gap-4">
+          <Input
+            placeholder="Buscar mensajes..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
+
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Usuario</TableHead>
+              <TableHead>Contenido</TableHead>
+              <TableHead>Evento</TableHead>
+              <TableHead>Fecha</TableHead>
+              <TableHead>Acciones</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filteredPosts.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={5} className="text-center">
+                  No se encontraron mensajes
+                </TableCell>
+              </TableRow>
+            ) : (
+              filteredPosts.map((post) => (
+                <TableRow key={post.id}>
+                  <TableCell>
+                    <div className="flex items-center gap-2">
+                      <span>{post.user.name}</span>
+                      {post.user.role === "actor" && (
+                        <span className="text-xs bg-purple-100 text-purple-700 px-2 py-1 rounded-full">
+                          Actor
+                        </span>
+                      )}
+                    </div>
+                  </TableCell>
+                  <TableCell className="max-w-[300px] truncate">
+                    {post.content}
+                  </TableCell>
+                  <TableCell>
+                    <Button
+                      variant="link"
+                      onClick={() => router.push(`/eventos/${post.event.id}`)}
+                    >
+                      {post.event.name}
+                    </Button>
+                  </TableCell>
+                  <TableCell>{formatDate(post.created_at)}</TableCell>
+                  <TableCell>
+                    <div className="flex gap-2">
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        onClick={() => handleDelete(post.id)}
+                      >
+                        Eliminar
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+} 

--- a/app/api/admin/forum/posts/route.ts
+++ b/app/api/admin/forum/posts/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { UUIDSchema } from "@/schemas/events";
+
+export async function GET(req: NextRequest) {
+  const supabase = await createClient();
+  
+  try {
+    // Validate admin
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ error: "No autorizado" }, { status: 401 });
+    }
+    
+    const { data: userData } = await supabase.from("users").select("role").eq("id", user.id).single();
+    if (!userData || userData.role !== "admin") {
+      return NextResponse.json({ error: "Acceso denegado" }, { status: 403 });
+    }
+
+    // Get all forum posts with user info
+    const { data, error } = await supabase
+      .from("forum_posts")
+      .select(`
+        *,
+        user:user_id(id, name, role),
+        event:event_id(id, name)
+      `)
+      .order("created_at", { ascending: false });
+
+    if (error) throw error;
+    return NextResponse.json(data);
+    
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Error al obtener los mensajes del foro" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+  const supabase = await createClient();
+  const postId = params.id;
+
+  try {
+    // Validate admin
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ error: "No autorizado" }, { status: 401 });
+    }
+    
+    const { data: userData } = await supabase.from("users").select("role").eq("id", user.id).single();
+    if (!userData || userData.role !== "admin") {
+      return NextResponse.json({ error: "Acceso denegado" }, { status: 403 });
+    }
+
+    // Validate post ID
+    const validated = UUIDSchema.safeParse(postId);
+    if (!validated.success) {
+      return NextResponse.json({ error: "ID de mensaje inválido" }, { status: 400 });
+    }
+
+    // Delete post
+    const { error: deleteError } = await supabase
+      .from("forum_posts")
+      .delete()
+      .eq("id", postId);
+
+    if (deleteError) throw deleteError;
+    return NextResponse.json({ success: true });
+
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Error al eliminar el mensaje" },
+      { status: 500 }
+    );
+  }
+} 

--- a/app/api/events/[id]/forum/route.ts
+++ b/app/api/events/[id]/forum/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { UUIDSchema } from "@/schemas/events";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const supabase = await createClient();
+  const id = params.id;
+
+  // Validate UUID
+  const validated = UUIDSchema.safeParse(id);
+  if (!validated.success) {
+    return NextResponse.json({ error: "Invalid event ID" }, { status: 400 });
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from("forum_posts")
+      .select(`
+        *,
+        user:user_id(id, name)
+      `)
+      .eq("event_id", id)
+      .order("created_at", { ascending: false });
+
+    if (error) throw error;
+
+    return NextResponse.json(data);
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Failed to fetch forum posts" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const supabase = await createClient();
+  const id = params.id;
+  const body = await req.json();
+
+  // Validate input
+  if (!body.content || !body.userId) {
+    return NextResponse.json(
+      { error: "Missing required fields" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from("forum_posts")
+      .insert([{
+        event_id: id,
+        user_id: body.userId,
+        content: body.content,
+        parent_id: body.parentId || null
+      }])
+      .select();
+
+    if (error) throw error;
+
+    return NextResponse.json(data[0], { status: 201 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json(
+      { error: "Failed to create post" },
+      { status: 500 }
+    );
+  }
+} 

--- a/app/api/events/[id]/forum/route.ts
+++ b/app/api/events/[id]/forum/route.ts
@@ -7,7 +7,7 @@ export async function GET(
   { params }: { params: { id: string } }
 ) {
   const supabase = await createClient();
-  const id = params.id;
+  const id = await params.id;
 
   // Validate UUID
   const validated = UUIDSchema.safeParse(id);
@@ -20,7 +20,7 @@ export async function GET(
       .from("forum_posts")
       .select(`
         *,
-        user:user_id(id, name)
+        user:user_id(id, name, role)
       `)
       .eq("event_id", id)
       .order("created_at", { ascending: false });
@@ -67,7 +67,6 @@ export async function POST(
 
     return NextResponse.json(data[0], { status: 201 });
   } catch (error) {
-    console.error(error);
     return NextResponse.json(
       { error: "Failed to create post" },
       { status: 500 }

--- a/components/events/event-forum.tsx
+++ b/components/events/event-forum.tsx
@@ -15,6 +15,72 @@ interface EventForumProps {
   eventId: string
 }
 
+function ForumPost({ 
+  post,
+  onReply,
+  depth = 0 
+}: { 
+  post: ForumPostWithUser;
+  onReply: (postId: string) => void;
+  depth?: number;
+}) {
+  const maxDepth = 3; // Prevent infinite nesting
+  if (depth > maxDepth) return null;
+
+  return (
+    <div 
+      className={`border rounded-lg p-4 ${depth > 0 ? 'ml-8 mt-4' : 'mb-4'}`}
+      style={{ marginLeft: `${depth * 2}rem` }}
+    >
+      <div className="flex gap-4">
+        <Avatar className="w-10 h-10">
+          <AvatarImage src={post.user?.avatar_url || ""} alt={post.user?.name || "Usuario"} />
+          <AvatarFallback>{(post.user?.name || "U").substring(0, 2).toUpperCase()}</AvatarFallback>
+        </Avatar>
+        <div className="flex-1">
+          <div className="flex items-center gap-2 mb-1">
+            <span className="font-medium">{post.user?.name || "Usuario"}</span>
+            {post.user?.role === "actor" && (
+              <span className="bg-purple-100 text-purple-700 text-xs px-2 py-1 rounded-full">Actor</span>
+            )}
+            <span className="text-gray-500 text-sm">
+              {new Date(post.created_at).toLocaleString("es-ES", {
+                day: "numeric",
+                month: "short",
+                hour: "2-digit",
+                minute: "2-digit",
+              })}
+            </span>
+          </div>
+          <p className="text-gray-700">{post.content}</p>
+          {onReply && (
+            <button
+              onClick={() => onReply(post.id)}
+              className="text-sm text-purple-600 mt-2 hover:underline"
+            >
+              Responder
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Render nested replies */}
+      {post.replies && post.replies.length > 0 && (
+        <div className="mt-4 space-y-4">
+          {post.replies.map((reply) => (
+            <ForumPost 
+              key={reply.id} 
+              post={reply} 
+              onReply={onReply}
+              depth={depth + 1}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function EventForum({ eventId }: EventForumProps) {
   const [message, setMessage] = useState("")
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -112,70 +178,11 @@ export function EventForum({ eventId }: EventForumProps) {
       ) : (
         <div className="space-y-6 mb-8">
           {posts.map((post) => (
-            <div key={post.id} className="border rounded-lg p-4">
-              <div className="flex gap-4">
-                <Avatar className="w-10 h-10">
-                  <AvatarImage src={post.user?.avatar_url || ""} alt={post.user?.name || "Usuario"} />
-                  <AvatarFallback>{(post.user?.name || "U").substring(0, 2).toUpperCase()}</AvatarFallback>
-                </Avatar>
-                <div className="flex-1">
-                  <div className="flex items-center gap-2 mb-1">
-                    <span className="font-medium">{post.user?.name || "Usuario"}</span>
-                    {post.user?.role === "actor" && (
-                      <span className="bg-purple-100 text-purple-700 text-xs px-2 py-1 rounded-full">Actor</span>
-                    )}
-                    <span className="text-gray-500 text-sm">
-                      {new Date(post.created_at).toLocaleString("es-ES", {
-                        day: "numeric",
-                        month: "short",
-                        hour: "2-digit",
-                        minute: "2-digit",
-                      })}
-                    </span>
-                  </div>
-                  <p className="text-gray-700">{post.content}</p>
-                  {isLoggedIn && (
-                    <button
-                      onClick={() => handleReply(post.id)}
-                      className="text-sm text-purple-600 mt-2 hover:underline"
-                    >
-                      Responder
-                    </button>
-                  )}
-                </div>
-              </div>
-
-              {/* Replies */}
-              {post.replies && post.replies.length > 0 && (
-                <div className="ml-12 mt-4 space-y-4">
-                  {post.replies.map((reply) => (
-                    <div key={reply.id} className="flex gap-4 border-l-2 border-gray-200 pl-4">
-                      <Avatar className="w-8 h-8">
-                        <AvatarImage src={reply.user?.avatar_url || ""} alt={reply.user?.name || "Usuario"} />
-                        <AvatarFallback>{(reply.user?.name || "U").substring(0, 2).toUpperCase()}</AvatarFallback>
-                      </Avatar>
-                      <div className="flex-1">
-                        <div className="flex items-center gap-2 mb-1">
-                          <span className="font-medium">{reply.user?.name || "Usuario"}</span>
-                          {reply.user?.role === "actor" && (
-                            <span className="bg-purple-100 text-purple-700 text-xs px-2 py-1 rounded-full">Actor</span>
-                          )}
-                          <span className="text-gray-500 text-sm">
-                            {new Date(reply.created_at).toLocaleString("es-ES", {
-                              day: "numeric",
-                              month: "short",
-                              hour: "2-digit",
-                              minute: "2-digit",
-                            })}
-                          </span>
-                        </div>
-                        <p className="text-gray-700">{reply.content}</p>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
+            <ForumPost 
+              key={post.id} 
+              post={post} 
+              onReply={handleReply}
+            />
           ))}
         </div>
       )}

--- a/components/events/event-forum.tsx
+++ b/components/events/event-forum.tsx
@@ -58,14 +58,12 @@ export function EventForum({ eventId }: EventForumProps) {
     setError(null)
 
     try {
-      const postData = {
+      await createForumPost({
         event_id: eventId,
         user_id: user.id,
         content: message,
-        parent_id: replyTo,
-      }
-
-      await createForumPost(postData)
+        parent_id: replyTo
+      })
 
       // Refresh posts
       const forumPosts = await getEventForumPosts(eventId)

--- a/lib/data-service.ts
+++ b/lib/data-service.ts
@@ -376,3 +376,30 @@ export async function updateUserProfile(
 
   return data[0]
 }
+
+export async function getEventForum(eventId: string) {
+  const { data, error } = await supabase
+    .from('forums')
+    .select('*, forum_messages(*)')
+    .eq('event_id', eventId)
+    .single();
+
+  if (error && error.code !== 'PGRST116') throw error;
+  return data;
+}
+
+export async function createForumMessage({
+  forumId,
+  userId,
+  content
+}: {
+  forumId: string;
+  userId: string;
+  content: string;
+}) {
+  return supabase
+    .from('forum_messages')
+    .insert({ forum_id: forumId, user_id: userId, content })
+    .select()
+    .single();
+}

--- a/lib/data-service.ts
+++ b/lib/data-service.ts
@@ -290,54 +290,35 @@ export async function updateTicketStatus(ticketId: string, status: "reserved" | 
 }
 
 // Forum Posts
-export async function getEventForumPosts(eventId: string) {
-  // First get top-level posts
-  const { data: topLevelPosts, error } = await supabase
-    .from("forum_posts")
-    .select(`
-      *,
-      user:user_id(id, name)
-    `)
-    .eq("event_id", eventId)
-    .is("parent_id", null)
-    .order("created_at", { ascending: false })
-
-  if (error) {
-    console.error("Error fetching forum posts:", error)
-    return []
+export async function getEventForumPosts(eventId: string): Promise<ForumPostWithUser[]> {
+  try {
+    const response = await fetch(`/api/events/${eventId}/forum`);
+    if (!response.ok) throw new Error('Failed to fetch posts');
+    return await response.json();
+  } catch (error) {
+    console.error("Error fetching forum posts:", error);
+    return [];
   }
-
-  // Then get replies for each post
-  const postsWithReplies = await Promise.all(
-    topLevelPosts.map(async (post) => {
-      const { data: replies } = await supabase
-        .from("forum_posts")
-        .select(`
-          *,
-          user:user_id(id, name)
-        `)
-        .eq("parent_id", post.id)
-        .order("created_at", { ascending: true })
-
-      return {
-        ...post,
-        replies: replies || [],
-      }
-    }),
-  )
-
-  return postsWithReplies
 }
 
 export async function createForumPost(postData: Omit<ForumPost, "id" | "created_at">) {
-  const { data, error } = await supabase.from("forum_posts").insert([postData]).select()
-
-  if (error) {
-    console.error("Error creating forum post:", error)
-    throw error
+  try {
+    const response = await fetch(`/api/events/${postData.event_id}/forum`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        userId: postData.user_id,
+        content: postData.content,
+        parentId: postData.parent_id
+      })
+    });
+    
+    if (!response.ok) throw new Error('Failed to create post');
+    return await response.json();
+  } catch (error) {
+    console.error("Error creating forum post:", error);
+    throw error;
   }
-
-  return data[0]
 }
 
 export async function deleteForumPost(postId: string) {

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -1,213 +1,464 @@
-export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[]
-
-export interface Database {
+export type Database = {
   public: {
     Tables: {
-      users: {
-        Row: {
-          id: string
-          created_at: string
-          name: string
-          role: "admin" | "user" | "actor"
-        }
-        Insert: {
-          id: string
-          created_at?: string
-          name: string
-          role?: "admin" | "user" | "actor"
-        }
-        Update: {
-          id?: string
-          created_at?: string
-          name?: string
-          role?: "admin" | "user" | "actor"
-        }
-      }
-      events: {
-        Row: {
-          id: string
-          created_at: string
-          name: string
-          description: string
-          date: string
-          time: string
-          image_url: string
-          sale_start_time: string
-          status: "upcoming" | "active" | "completed"
-        }
-        Insert: {
-          id?: string
-          created_at?: string
-          name: string
-          description: string
-          date: string
-          time: string
-          image_url?: string
-          sale_start_time: string
-          status?: "upcoming" | "active" | "completed"
-        }
-        Update: {
-          id?: string
-          created_at?: string
-          name?: string
-          description?: string
-          date?: string
-          time?: string
-          image_url?: string
-          sale_start_time?: string
-          status?: "upcoming" | "active" | "completed"
-        }
-      }
       actors: {
         Row: {
-          id: string
-          created_at: string
-          name: string
           bio: string
-          photo_url: string
+          created_at: string | null
+          id: string
+          name: string
+          photo_url: string | null
         }
         Insert: {
-          id?: string
-          created_at?: string
-          name: string
           bio: string
-          photo_url?: string
+          created_at?: string | null
+          id?: string
+          name: string
+          photo_url?: string | null
         }
         Update: {
-          id?: string
-          created_at?: string
-          name?: string
           bio?: string
-          photo_url?: string
+          created_at?: string | null
+          id?: string
+          name?: string
+          photo_url?: string | null
         }
+        Relationships: []
       }
       event_actors: {
         Row: {
-          id: string
-          event_id: string
           actor_id: string
+          event_id: string
+          id: string
         }
         Insert: {
-          id?: string
-          event_id: string
           actor_id: string
+          event_id: string
+          id?: string
         }
         Update: {
-          id?: string
-          event_id?: string
           actor_id?: string
+          event_id?: string
+          id?: string
         }
+        Relationships: [
+          {
+            foreignKeyName: "event_actors_actor_id_fkey"
+            columns: ["actor_id"]
+            isOneToOne: false
+            referencedRelation: "actors"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "event_actors_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "events"
+            referencedColumns: ["id"]
+          },
+        ]
       }
-      queue: {
+      events: {
         Row: {
+          created_at: string | null
+          date: string
+          description: string
           id: string
+          image_url: string | null
+          name: string
+          sale_start_time: string
+          status: string | null
+          time: string
+        }
+        Insert: {
+          created_at?: string | null
+          date: string
+          description: string
+          id?: string
+          image_url?: string | null
+          name: string
+          sale_start_time: string
+          status?: string | null
+          time: string
+        }
+        Update: {
+          created_at?: string | null
+          date?: string
+          description?: string
+          id?: string
+          image_url?: string | null
+          name?: string
+          sale_start_time?: string
+          status?: string | null
+          time?: string
+        }
+        Relationships: []
+      }
+      forum_messages: {
+        Row: {
+          content: string
           created_at: string
-          user_id: string
-          event_id: string
-          position: number
-          status: "waiting" | "active" | "completed" | "expired"
-          token: string
-        }
-        Insert: {
-          id?: string
-          created_at?: string
-          user_id: string
-          event_id: string
-          position: number
-          status?: "waiting" | "active" | "completed" | "expired"
-          token: string
-        }
-        Update: {
-          id?: string
-          created_at?: string
-          user_id?: string
-          event_id?: string
-          position?: number
-          status?: "waiting" | "active" | "completed" | "expired"
-          token?: string
-        }
-      }
-      seats: {
-        Row: {
+          forum_id: string
           id: string
-          event_id: string
-          row: string
-          number: number
-          price: number
-          status: "available" | "reserved" | "sold"
+          user_id: string
         }
         Insert: {
+          content: string
+          created_at?: string
+          forum_id: string
           id?: string
-          event_id: string
-          row: string
-          number: number
-          price: number
-          status?: "available" | "reserved" | "sold"
+          user_id: string
         }
         Update: {
-          id?: string
-          event_id?: string
-          row?: string
-          number?: number
-          price?: number
-          status?: "available" | "reserved" | "sold"
-        }
-      }
-      tickets: {
-        Row: {
-          id: string
-          created_at: string
-          user_id: string
-          event_id: string
-          seat_id: string
-          purchase_date: string
-          status: "reserved" | "purchased" | "cancelled"
-        }
-        Insert: {
-          id?: string
+          content?: string
           created_at?: string
-          user_id: string
-          event_id: string
-          seat_id: string
-          purchase_date?: string
-          status?: "reserved" | "purchased" | "cancelled"
-        }
-        Update: {
+          forum_id?: string
           id?: string
-          created_at?: string
           user_id?: string
-          event_id?: string
-          seat_id?: string
-          purchase_date?: string
-          status?: "reserved" | "purchased" | "cancelled"
         }
+        Relationships: [
+          {
+            foreignKeyName: "forum_messages_forum_id_fkey"
+            columns: ["forum_id"]
+            isOneToOne: false
+            referencedRelation: "forums"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       forum_posts: {
         Row: {
-          id: string
-          created_at: string
-          event_id: string
-          user_id: string
           content: string
+          created_at: string | null
+          event_id: string
+          id: string
           parent_id: string | null
+          user_id: string
         }
         Insert: {
-          id?: string
-          created_at?: string
-          event_id: string
-          user_id: string
           content: string
+          created_at?: string | null
+          event_id: string
+          id?: string
           parent_id?: string | null
+          user_id: string
         }
         Update: {
+          content?: string
+          created_at?: string | null
+          event_id?: string
           id?: string
+          parent_id?: string | null
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "forum_posts_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "events"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "forum_posts_parent_id_fkey"
+            columns: ["parent_id"]
+            isOneToOne: false
+            referencedRelation: "forum_posts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      forums: {
+        Row: {
+          created_at: string
+          event_id: string
+          id: string
+        }
+        Insert: {
+          created_at?: string
+          event_id: string
+          id?: string
+        }
+        Update: {
           created_at?: string
           event_id?: string
-          user_id?: string
-          content?: string
-          parent_id?: string | null
+          id?: string
         }
+        Relationships: [
+          {
+            foreignKeyName: "forums_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "events"
+            referencedColumns: ["id"]
+          },
+        ]
       }
+      queue: {
+        Row: {
+          created_at: string | null
+          event_id: string
+          id: string
+          position: number
+          status: string | null
+          token: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string | null
+          event_id: string
+          id?: string
+          position: number
+          status?: string | null
+          token: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string | null
+          event_id?: string
+          id?: string
+          position?: number
+          status?: string | null
+          token?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "queue_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "events"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      seats: {
+        Row: {
+          event_id: string
+          id: string
+          number: number
+          price: number
+          row: string
+          status: string | null
+        }
+        Insert: {
+          event_id: string
+          id?: string
+          number: number
+          price: number
+          row: string
+          status?: string | null
+        }
+        Update: {
+          event_id?: string
+          id?: string
+          number?: number
+          price?: number
+          row?: string
+          status?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "seats_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "events"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      tickets: {
+        Row: {
+          created_at: string | null
+          event_id: string
+          id: string
+          purchase_date: string | null
+          seat_id: string
+          status: string | null
+          user_id: string
+        }
+        Insert: {
+          created_at?: string | null
+          event_id: string
+          id?: string
+          purchase_date?: string | null
+          seat_id: string
+          status?: string | null
+          user_id: string
+        }
+        Update: {
+          created_at?: string | null
+          event_id?: string
+          id?: string
+          purchase_date?: string | null
+          seat_id?: string
+          status?: string | null
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "tickets_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "events"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "tickets_seat_id_fkey"
+            columns: ["seat_id"]
+            isOneToOne: false
+            referencedRelation: "seats"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      users: {
+        Row: {
+          created_at: string | null
+          id: string
+          name: string
+          role: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          id: string
+          name: string
+          role?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          id?: string
+          name?: string
+          role?: string | null
+        }
+        Relationships: []
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      is_admin: {
+        Args: Record<PropertyKey, never>
+        Returns: boolean
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
     }
   }
 }
+
+type DefaultSchema = Database[Extract<keyof Database, "public">]
+
+export type Tables<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof Database },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof (Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        Database[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
+  ? (Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      Database[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
+    : never
+
+export type TablesInsert<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof Database },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
+  ? Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
+    : never
+
+export type TablesUpdate<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof Database },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
+  ? Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
+    : never
+
+export type Enums<
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema["Enums"]
+    | { schema: keyof Database },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof Database[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends { schema: keyof Database }
+  ? Database[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof Database },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
+
+export const Constants = {
+  public: {
+    Enums: {},
+  },
+} as const

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -1,3 +1,11 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
 export type Database = {
   public: {
     Tables: {
@@ -94,38 +102,6 @@ export type Database = {
         }
         Relationships: []
       }
-      forum_messages: {
-        Row: {
-          content: string
-          created_at: string
-          forum_id: string
-          id: string
-          user_id: string
-        }
-        Insert: {
-          content: string
-          created_at?: string
-          forum_id: string
-          id?: string
-          user_id: string
-        }
-        Update: {
-          content?: string
-          created_at?: string
-          forum_id?: string
-          id?: string
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "forum_messages_forum_id_fkey"
-            columns: ["forum_id"]
-            isOneToOne: false
-            referencedRelation: "forums"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
       forum_posts: {
         Row: {
           content: string
@@ -133,6 +109,7 @@ export type Database = {
           event_id: string
           id: string
           parent_id: string | null
+          updated_at: string | null
           user_id: string
         }
         Insert: {
@@ -141,6 +118,7 @@ export type Database = {
           event_id: string
           id?: string
           parent_id?: string | null
+          updated_at?: string | null
           user_id: string
         }
         Update: {
@@ -149,6 +127,7 @@ export type Database = {
           event_id?: string
           id?: string
           parent_id?: string | null
+          updated_at?: string | null
           user_id?: string
         }
         Relationships: [
@@ -166,30 +145,11 @@ export type Database = {
             referencedRelation: "forum_posts"
             referencedColumns: ["id"]
           },
-        ]
-      }
-      forums: {
-        Row: {
-          created_at: string
-          event_id: string
-          id: string
-        }
-        Insert: {
-          created_at?: string
-          event_id: string
-          id?: string
-        }
-        Update: {
-          created_at?: string
-          event_id?: string
-          id?: string
-        }
-        Relationships: [
           {
-            foreignKeyName: "forums_event_id_fkey"
-            columns: ["event_id"]
+            foreignKeyName: "forum_posts_user_id_fkey"
+            columns: ["user_id"]
             isOneToOne: false
-            referencedRelation: "events"
+            referencedRelation: "users"
             referencedColumns: ["id"]
           },
         ]


### PR DESCRIPTION
### Descripción

Este PR implementa la funcionalidad de foros para eventos, permitiendo a los usuarios ver, crear y responder a publicaciones relacionadas con un evento específico. Se integran tanto los endpoints backend como los componentes frontend necesarios para soportar la visualización anidada de comentarios.

Cambios principales:
 - Nuevo endpoint GET y POST en /api/events/[id]/forum para obtener y crear publicaciones del foro.
 - Componente ForumPost para renderizado recursivo de publicaciones con soporte para respuestas 

### Motivación y Contexto

Se busca habilitar discusiones en torno a eventos en la plataforma.

El enfoque de respuestas anidadas favorece la organización de las conversaciones, y la distinción visual de actores permite contextualizar los aportes según el rol del usuario.

### ¿Cómo ha sido probado?

Pruebas manuales en entorno local 
- Visualización de publicaciones de foro cargadas desde supabase
- Creación de nuevas publicaciones y respuestas
- Representación anidada de las respuestas
- Control de errores al enviar datos

## Capturas de pantalla:

N/A

## Tipos de cambios

- [ ] Bugfix (cambio que no interrumpe el funcionamiento y que soluciona un problema)
- [x] New feature (cambio que no interrumpe el funcionamiento y que añade funcionalidad)
- [ ] Breaking change (corrección o funcionalidad que podría causar que la funcionalidad existente cambie)

## Lista de verificación:

- [x] Mi código sigue el estilo de código de este proyecto.
- [ ] Mi cambio requiere una modificación en la documentación.
- [ ] He actualizado la documentación en consecuencia.
- [x] Requiere nuevos tests.